### PR TITLE
@ #44 | should check guest machine state before rsync trigger

### DIFF
--- a/lib/teracy-dev-essential/config/rsync_recovery.rb
+++ b/lib/teracy-dev-essential/config/rsync_recovery.rb
@@ -115,6 +115,13 @@ module TeracyDevEssential
       def configure_trigger_after(config)
         config.trigger.after :up, :reload, :resume do |trigger|
           trigger.ruby do |env, machine|
+            ready = machine.guest.ready?
+
+            unless ready
+              @logger.error("guest machine is not ready")
+              abort
+            end
+
             begin
               env.cli('gatling-rsync-auto')
               raise unless $?.exitstatus == 0


### PR DESCRIPTION
connect #44 
please check this PR! Thank you.

related: https://github.com/iorad/teracy-dev-entry/issues/58.

* This PR is not the solution to fix the error of issue https://github.com/iorad/teracy-dev-entry/issues/58. This is a condition for running rsync trigger. To avoid an infinite loop when a guest machine is not ready.