### PR TITLE
rsync recovery: fix silent error

### DIFF
--- a/lib/teracy-dev-essential/config/rsync_recovery.rb
+++ b/lib/teracy-dev-essential/config/rsync_recovery.rb
@@ -2,6 +2,9 @@ require 'teracy-dev/config/configurator'
 require 'teracy-dev/plugin'
 require 'teracy-dev/util'
 
+class NonZeroExit < StandardError
+end
+
 module TeracyDevEssential
   module Config
     class RsyncRecovery < TeracyDev::Config::Configurator
@@ -147,8 +150,8 @@ module TeracyDevEssential
               begin
                 env.cli(@cmd)
 
-                raise unless $?.exitstatus == 0
-              rescue
+                raise NonZeroExit unless $?.exitstatus == 0
+              rescue NonZeroExit
                 @logger.warn('gatling-rsync-auto crashed, retrying...')
 
                 retry


### PR DESCRIPTION
https://github.com/teracyhq-incubator/teracy-dev-essential/compare/develop...oeeq:rsync_recovery_fix_silent_error#diff-86d26b1b2c99557f77b4b6e751c3fb11R151
At the line above, when `env.cli` fails with an error, the message is not printed and the script goes to an infinite loop of retries.
I don't know about ruby conventions, you may want to adjust the fix.